### PR TITLE
Use logging for question analyzer and configurable log level

### DIFF
--- a/codexhorary/backend/app.py
+++ b/codexhorary/backend/app.py
@@ -66,21 +66,15 @@ def safe_log(logger, level, message):
 
 
 # Configure logging
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 
 logging.basicConfig(
-
-    level=logging.INFO,
-
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-
+    level=getattr(logging, log_level, logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[
-
-        logging.FileHandler('horary_api.log'),
-
-        logging.StreamHandler()
-
-    ]
-
+        logging.FileHandler("horary_api.log"),
+        logging.StreamHandler(),
+    ],
 )
 
 

--- a/codexhorary/backend/question_analyzer.py
+++ b/codexhorary/backend/question_analyzer.py
@@ -1,5 +1,8 @@
 from typing import Dict, Any, List
 import re
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class TraditionalHoraryQuestionAnalyzer:
@@ -165,7 +168,12 @@ class TraditionalHoraryQuestionAnalyzer:
         significators = self._determine_significators(houses, question_type, possession_analysis, third_person_analysis)
 
         # DEBUG: Emit classification traceability information
-        print(f"DEBUG: category={question_type}, matched={matched_pattern}, houses={houses}")
+        logger.debug(
+            "category=%s, matched=%s, houses=%s",
+            question_type,
+            matched_pattern,
+            houses,
+        )
 
         return {
             "question_type": question_type,


### PR DESCRIPTION
## Summary
- Switch question analyzer from print debugging to Python logging
- Allow Flask app logging level to be set via `LOG_LEVEL` environment variable

## Testing
- `python -m py_compile backend/question_analyzer.py backend/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09b52211483248545f13c4b9c65bb