### PR TITLE
Verify applying perfection paths

### DIFF
--- a/codexhorary/backend/test_evaluate_chart.py
+++ b/codexhorary/backend/test_evaluate_chart.py
@@ -1,0 +1,33 @@
+import pytest
+from evaluate_chart import _phase_b_primary_success, evaluate_chart
+
+
+def test_primary_success_filters_non_applying_paths():
+    chart = {
+        'aspect_timeline': [
+            {'type': 'direct', 'status': 'separating'},
+            {'type': 'translation', 'status': 'applying'},
+            {'type': 'collection', 'status': 'perfected'},
+        ]
+    }
+
+    baseline = _phase_b_primary_success(chart)
+    assert baseline is True
+    assert chart['paths'] == ['translation']
+    assert chart['rejected_paths'] == ['direct', 'collection']
+    assert 'path:translation' in chart['proof']
+
+
+def test_evaluate_chart_rejects_only_perfected_paths():
+    chart = {
+        'aspect_timeline': [
+            {'type': 'direct', 'status': 'perfected'}
+        ]
+    }
+
+    result = evaluate_chart(chart)
+    # No applying paths, so verdict should be NO
+    assert result['verdict'] == 'NO'
+    assert chart['paths'] == []
+    assert chart['rejected_paths'] == ['direct']
+    assert 'no-path' in result['proof']


### PR DESCRIPTION
## Summary
- Ensure direct, translation, and collection paths are only accepted when aspects are applying
- Track and expose rejected paths where aspects are separating or perfected
- Add regression tests for path validation and overall evaluation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09fd7392c83249564f785d4b0c063