### PR TITLE
Weight indirect perfection paths

### DIFF
--- a/codexhorary/backend/test_evaluate_chart.py
+++ b/codexhorary/backend/test_evaluate_chart.py
@@ -1,5 +1,9 @@
 import pytest
-from evaluate_chart import _phase_b_primary_success, evaluate_chart
+from evaluate_chart import (
+    WEIGHT_TRANSLATION,
+    _phase_b_primary_success,
+    evaluate_chart,
+)
 
 
 def test_primary_success_filters_non_applying_paths():
@@ -11,8 +15,9 @@ def test_primary_success_filters_non_applying_paths():
         ]
     }
 
-    baseline = _phase_b_primary_success(chart)
-    assert baseline is True
+    baseline, bonus = _phase_b_primary_success(chart)
+    assert baseline is False
+    assert bonus == WEIGHT_TRANSLATION
     assert chart['paths'] == ['translation']
     assert chart['rejected_paths'] == ['direct', 'collection']
     assert 'path:translation' in chart['proof']
@@ -31,3 +36,16 @@ def test_evaluate_chart_rejects_only_perfected_paths():
     assert chart['paths'] == []
     assert chart['rejected_paths'] == ['direct']
     assert 'no-path' in result['proof']
+
+
+def test_translation_path_only_modifies_confidence():
+    chart = {
+        'aspect_timeline': [
+            {'type': 'translation', 'status': 'applying'}
+        ]
+    }
+
+    result = evaluate_chart(chart)
+    assert result['verdict'] == 'NO'
+    assert result['confidence'] == pytest.approx(0.2 + WEIGHT_TRANSLATION)
+    assert 'path:translation' in result['proof']


### PR DESCRIPTION
## Summary
- add explicit weights for direct, translation, and collection paths
- compute path weight bonus without granting success for indirect connections
- adjust overall evaluation to apply bonus to confidence only
- cover weighted logic with updated and new tests

## Testing
- `pytest backend/test_evaluate_chart.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a8efdf448324833b55b992f9bc4c