### PR TITLE
Handle indirect baseline in chart evaluation

### DIFF
--- a/codexhorary/backend/test_evaluate_chart.py
+++ b/codexhorary/backend/test_evaluate_chart.py
@@ -15,9 +15,10 @@ def test_primary_success_filters_non_applying_paths():
         ]
     }
 
-    baseline, bonus = _phase_b_primary_success(chart)
+    baseline, bonus, indirect = _phase_b_primary_success(chart)
     assert baseline is False
     assert bonus == WEIGHT_TRANSLATION
+    assert indirect is True
     assert chart['paths'] == ['translation']
     assert chart['rejected_paths'] == ['direct', 'collection']
     assert 'path:translation' in chart['proof']
@@ -38,7 +39,7 @@ def test_evaluate_chart_rejects_only_perfected_paths():
     assert 'no-path' in result['proof']
 
 
-def test_translation_path_only_modifies_confidence():
+def test_translation_path_yields_indirect_success():
     chart = {
         'aspect_timeline': [
             {'type': 'translation', 'status': 'applying'}
@@ -46,6 +47,6 @@ def test_translation_path_only_modifies_confidence():
     }
 
     result = evaluate_chart(chart)
-    assert result['verdict'] == 'NO'
-    assert result['confidence'] == pytest.approx(0.2 + WEIGHT_TRANSLATION)
+    assert result['verdict'] == 'YES'
+    assert result['confidence'] == pytest.approx(0.5 + WEIGHT_TRANSLATION)
     assert 'path:translation' in result['proof']


### PR DESCRIPTION
## Summary
- Capture indirect baseline when translation or collection applies and no direct path exists
- Treat indirect baseline as success in overall chart evaluation
- Adjust tests for new indirect success behavior

## Testing
- `cd codexhorary/backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ae2c15c08324a93b90796a985de2